### PR TITLE
Split apart visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Started this shell based on this [ChatGPT conversation](https://chatgpt.com/shar
 
 ### TODO
 
+* Rotate the turn number labels
+
 * Sentence case everywhere
 * Enhance the Methodology section
 * Add a FAQ section
@@ -51,10 +53,24 @@ Started this shell based on this [ChatGPT conversation](https://chatgpt.com/shar
 * Change from the negative "dead cards" to the positive "castable spells"
 * Track for each spell (by key) (a) how often it is in hand, (b) how often it is castable, (c) % of time castable, (d) total mana cost, and (e) % castable over mana cost. Sort by (e) descending
 
+* Make the visualizations searchable
+
 * Add an example in the About for how to enter the JSON
 
 * Limit the number of simulations that can be run to 1,000
 * Limit the number of draw steps to 20
+
+* Change the spells / mana input to a single "deck" iput with something like:
+
+```
+"4*U"  # a 4 generic 1 blue mana spell
+">BU"  # a land that produces black or blue mana
+"2*>*" # a 2 generic spell that can then be tapped immediately for any mana color (e.g., Tortoise)
+"3*|WUBRG"  # a 3 generic spell that can tutor for any basic land
+"*U>*/" # a one generic one blue spell that can tap for generic mana but enters tapped
+">UB/" # a blue / white mana that enters tapped
+```
+maybe have a conversation with ChatGPT about how to represent all these things
 
 * Keep track of a version number displayed somewhere on the main page
 (maybe in the main page)

--- a/README.md
+++ b/README.md
@@ -43,13 +43,15 @@ Started this shell based on this [ChatGPT conversation](https://chatgpt.com/shar
 
 ### TODO
 
-* Update the About
+* Sentence case everywhere
+* Enhance the Methodology section
+* Add a FAQ section
+* Choose a name
+
+* Change from the negative "dead cards" to the positive "castable spells"
+* Track for each spell (by key) (a) how often it is in hand, (b) how often it is castable, (c) % of time castable, (d) total mana cost, and (e) % castable over mana cost. Sort by (e) descending
 
 * Add an example in the About for how to enter the JSON
-
-* Create four sectionss -- title / run & help / input / output, and improve the visual design
-
-* Add tooltips
 
 * Limit the number of simulations that can be run to 1,000
 * Limit the number of draw steps to 20

--- a/lib/mana.py
+++ b/lib/mana.py
@@ -4,7 +4,6 @@ import re
 from collections import Counter
 import numpy as np
 import pandas as pd
-import altair as alt
 
 CANONICAL_COLORS = ['W', 'U', 'B', 'R', 'G']
 CANONICAL_COLOR_VALUES = ['grey', 'blue', 'black', 'red', 'green']
@@ -12,9 +11,9 @@ CANONICAL_COLOR_VALUES = ['grey', 'blue', 'black', 'red', 'green']
 def parse_cost_string(cost_str):
     """
     Parse a cost string like 'U', '3U', '4*', '4*U2W', etc.
-    Returns (uncolored_cost, color_costs_dict), where:
-      - uncolored_cost is an integer (sum of any digits preceding '*')
-      - color_costs_dict is a Counter, e.g. {'U': 1, 'W': 2}
+    Returns (uncolored_cost, color_costs_dict).
+    Example:
+      '4*U2W' -> (4, {'U':1, 'W':2})
     """
     pattern = r'(\d*\*|\d*[WUBRG])'
     matches = re.findall(pattern, cost_str)
@@ -37,6 +36,7 @@ def parse_cost_string(cost_str):
 
     return uncolored, color_costs
 
+
 class Spell:
     def __init__(self, cost_str: str):
         self.cost_str = cost_str
@@ -44,6 +44,7 @@ class Spell:
 
     def __repr__(self) -> str:
         return f"Spell(cost='{self.cost_str}')"
+
 
 class Mana:
     """
@@ -57,17 +58,20 @@ class Mana:
     def __repr__(self) -> str:
         return f"Mana(mana='{self.mana_str}')"
 
+
 def all_possible_color_combinations(mana_cards):
     """
-    For a list of Mana objects, yield all possible ways
-    they could collectively produce mana.
+    Given a list of Mana objects, yields all possible ways
+    they could collectively produce mana (as a list of Counters).
     """
     combos = itertools.product(*(m.producible_colors for m in mana_cards))
     return [Counter(combo) for combo in combos]
 
+
 def can_cast(spell, mana_cards, lands_playable):
     """
     Check if 'spell' can be cast using up to 'lands_playable' mana cards.
+    The function tries subsets of the available mana cards.
     """
     needed_total = spell.uncolored_cost + sum(spell.required_colors.values())
     if needed_total > lands_playable:
@@ -83,13 +87,15 @@ def can_cast(spell, mana_cards, lands_playable):
             subset = [mana_cards[i] for i in subset_indices]
             for combo_counter in all_possible_color_combinations(subset):
                 # Check color requirements
-                if all(combo_counter[color] >= spell.required_colors[color] for color in spell.required_colors):
-                    # Check uncolored (leftover) requirement
+                if all(combo_counter[color] >= spell.required_colors[color]
+                       for color in spell.required_colors):
+                    # Check leftover (uncolored) mana
                     color_lands_used = sum(spell.required_colors[c] for c in spell.required_colors)
                     leftover = subset_size - color_lands_used
                     if leftover >= spell.uncolored_cost:
                         return True
     return False
+
 
 class Deck:
     def __init__(self, spells, mana_cards, total_size=40):
@@ -100,6 +106,7 @@ class Deck:
         self.deck_list = spells + mana_cards
         leftover = total_size - len(self.deck_list)
         if leftover > 0:
+            # Fill remaining with None
             self.deck_list += [None] * leftover
 
     def shuffle(self):
@@ -117,7 +124,12 @@ class Deck:
             f"mana={len(self.mana_cards)}, actual_list_len={len(self.deck_list)})"
         )
 
+
 def build_deck_from_dicts(spells_dict, mana_dict, total_deck_size=40):
+    """
+    Builds a Deck from the spells_dict and mana_dict,
+    each of which map strings -> quantity.
+    """
     spells = []
     for cost_str, qty in spells_dict.items():
         for _ in range(qty):
@@ -130,11 +142,15 @@ def build_deck_from_dicts(spells_dict, mana_dict, total_deck_size=40):
 
     return Deck(spells, mana_cards, total_deck_size)
 
+
 def _count_dead_spells(hand, turn, on_play):
     """
-    Count spells in 'hand' that are uncastable on a given turn,
+    Count how many spells in 'hand' are uncastable on a given turn,
     considering how many lands you could have played.
     """
+    # If on the play, on turn X, you can have played X lands (turns 1..X).
+    # If on the draw, on turn X, you can have played X-1 lands (since you drew first).
+    # The code below uses turn+1 if on_play, else turn.
     lands_playable = turn + 1 if on_play else turn
     if lands_playable < 0:
         lands_playable = 0
@@ -148,11 +164,12 @@ def _count_dead_spells(hand, turn, on_play):
             dead_count += 1
     return dead_count
 
+
 def _best_single_color_to_replace(hand, turn, on_play, colors_to_test=CANONICAL_COLORS):
     """
-    Which single-color land replacement reduces dead spells the most?
-    We consider replacing exactly one of the existing lands in `hand` with a
-    single-color Mana(...) from `colors_to_test`.
+    Determine which single-color land replacement reduces dead spells the most.
+    We consider replacing exactly one of the existing Mana cards in `hand`
+    with a single-color Mana(...) from `colors_to_test`.
     """
 
     base_dead = _count_dead_spells(hand, turn, on_play)
@@ -164,17 +181,14 @@ def _best_single_color_to_replace(hand, turn, on_play, colors_to_test=CANONICAL_
         return "none"
 
     best_color = "none"
-    best_dead_count = base_dead  # We want to minimize dead spells
+    best_dead_count = base_dead  # we want to minimize dead spells
 
     for color in colors_to_test:
-        # We'll see if replacing *any* single land with this color helps
-        # Track the best scenario for this color
+        # We'll see if replacing *any* single land with this color helps.
         best_for_this_color = base_dead
 
         for land_index, original_land in enumerate(hand_mana):
-            # Replace original_land with a new Mana(color)
             hypothetical_hand = hand.copy()
-            # We only replace the first occurrence in hand (which is fine for a test)
             idx_in_hand = hypothetical_hand.index(original_land)
             hypothetical_hand[idx_in_hand] = Mana(color)
 
@@ -182,12 +196,12 @@ def _best_single_color_to_replace(hand, turn, on_play, colors_to_test=CANONICAL_
             if new_dead < best_for_this_color:
                 best_for_this_color = new_dead
 
-        # If the best scenario for this color is better than any we've found so far, update
         if best_for_this_color < best_dead_count:
             best_dead_count = best_for_this_color
             best_color = color
 
     return best_color
+
 
 def run_simulation(spells_dict,
                    mana_dict,
@@ -198,16 +212,18 @@ def run_simulation(spells_dict,
                    seed=None,
                    on_play=True):
     """
-    Returns:
-        - df_summary (stats per turn, including p_dead and best-color picks)
-        - df_distribution (distribution of dead spell counts per turn)
+    Runs the simulation and returns two DataFrames:
+
+      df_summary      -> stats per turn, including p_dead and fraction of "best color" picks.
+      df_distribution -> distribution of dead spell counts per turn.
+
+    'on_play' indicates whether we are on the play (vs. on the draw).
     """
     if seed is not None:
         random.seed(seed)
 
     deck = build_deck_from_dicts(spells_dict, mana_dict, total_deck_size)
 
-    # We'll collect stats for turns 1..draws
     dead_counts_per_turn = [[] for _ in range(draws)]
     best_color_counts = [Counter() for _ in range(draws)]
 
@@ -215,8 +231,8 @@ def run_simulation(spells_dict,
         deck.shuffle()
 
         for turn in range(1, draws + 1):
-            # On the play => you do NOT draw on turn 1 => total draws so far is turn-1
-            # On the draw => you DO draw on turn 1 => total draws so far is turn
+            # On the play => no draw step on turn 1 => total draws so far = turn-1
+            # On the draw => there is a draw on turn 1 => total draws so far = turn
             if on_play:
                 hand_size = initial_hand_size + (turn - 1)
             else:
@@ -224,15 +240,13 @@ def run_simulation(spells_dict,
 
             hand = deck.draw_top_n(hand_size)
 
-            # Count dead spells
             dead_count = _count_dead_spells(hand, turn, on_play)
             dead_counts_per_turn[turn - 1].append(dead_count)
 
-            # Find best color to replace
             best_color = _best_single_color_to_replace(hand, turn, on_play)
             best_color_counts[turn - 1][best_color] += 1
 
-    # Build DataFrames
+    # Build df_summary
     rows_summary = []
     extended_colors = CANONICAL_COLORS + ["none"]
 
@@ -248,7 +262,7 @@ def run_simulation(spells_dict,
 
         row = {
             "turn": turn,
-            "turn_label": str(turn),  # Just use the turn number as label
+            "turn_label": str(turn),
             "p_dead": p_dead,
             **{f"pct_optimal_{c}": color_fracs[c] for c in extended_colors}
         }
@@ -256,6 +270,7 @@ def run_simulation(spells_dict,
 
     df_summary = pd.DataFrame(rows_summary)
 
+    # Build df_distribution
     distribution_rows = []
     for turn in range(1, draws + 1):
         counts = Counter(dead_counts_per_turn[turn - 1])
@@ -270,94 +285,3 @@ def run_simulation(spells_dict,
     df_distribution = pd.DataFrame(distribution_rows)
 
     return df_summary, df_distribution
-
-
-def create_altair_charts(df_summary, df_distribution):
-    plot_width = 600
-    plot_height = 300
-
-    # If we labeled turn from 1..draws, just sort them as strings
-    max_turn = int(df_summary["turn"].max()) if not df_summary.empty else 1
-    turn_sort = [str(i) for i in range(1, max_turn + 1)]
-
-    # Distribution chart
-    distribution_chart = (
-        alt.Chart(df_distribution)
-        .transform_joinaggregate(
-            total_simulations='sum(frequency)',
-            groupby=['turn_label']
-        )
-        .transform_calculate(
-            percent='datum.frequency / datum.total_simulations'
-        )
-        .transform_filter("datum.dead_spells > 0")
-        .mark_bar()
-        .encode(
-            x=alt.X(
-                "turn_label:N",
-                title="Turn number",     # <--- Updated here
-                scale=alt.Scale(domain=turn_sort)
-            ),
-            y=alt.Y(
-                "percent:Q",
-                title="Percent of simulations",
-                scale=alt.Scale(domain=[0, 1]),
-                axis=alt.Axis(format='%')
-            ),
-            color=alt.Color(
-                "dead_spells:O",
-                title="Dead spells",
-                scale=alt.Scale(scheme="magma", reverse=False)
-            ),
-            order=alt.Order("dead_spells:Q", sort="descending")
-        )
-        .properties(
-            width=plot_width,
-            height=plot_height,
-            title="Percent of simulations with a given number of dead spells"
-        )
-    )
-
-    # Bottom chart: fraction of times each color is best
-    df_colordist = df_summary.copy()
-    rename_map = {f"pct_optimal_{c}": c for c in CANONICAL_COLORS}
-    df_colordist.rename(columns=rename_map, inplace=True)
-
-    bottom_chart = (
-        alt.Chart(df_colordist)
-        .transform_fold(
-            CANONICAL_COLORS,
-            as_=["color_type", "pct"]
-        )
-        .mark_line()
-        .encode(
-            x=alt.X(
-                "turn_label:N",
-                scale=alt.Scale(domain=turn_sort),
-                title="Turn number"      # <--- Updated here
-            ),
-            y=alt.Y(
-                "pct:Q",
-                title="Percent of simulations",
-                axis=alt.Axis(format="%")
-            ),
-            color=alt.Color(
-                "color_type:N",
-                scale=alt.Scale(
-                    domain=CANONICAL_COLORS,
-                    range=CANONICAL_COLOR_VALUES
-                ),
-                legend=alt.Legend(title="Mana")
-            )
-        )
-        .properties(
-            width=plot_width,
-            height=plot_height,
-            title="Percent of simulations where switching a land to each color is optimal"
-        )
-    )
-
-    combined_chart = alt.vconcat(distribution_chart, bottom_chart).resolve_scale(
-        color="independent", x="shared"
-    )
-    return combined_chart

--- a/lib/viz.py
+++ b/lib/viz.py
@@ -1,0 +1,139 @@
+from abc import ABC, abstractmethod
+import altair as alt
+import pandas as pd
+
+from .mana import CANONICAL_COLORS, CANONICAL_COLOR_VALUES
+
+class BaseChart(ABC):
+    """
+    Abstract base class for Altair charts in this app.
+    Each chart class should:
+      - store references to the relevant data
+      - implement `render_spec` which returns the Altair JSON spec (as a Python dict)
+    """
+    def __init__(self, df: pd.DataFrame):
+        self.df = df
+
+    @abstractmethod
+    def render_spec(self) -> dict:
+        pass
+
+
+class DistributionChart(BaseChart):
+    """
+    Creates a bar chart of how often each number of dead spells occurs per turn,
+    ignoring the case of 0 dead spells.
+    """
+
+    def render_spec(self) -> dict:
+        plot_width = 600
+        plot_height = 300
+
+        if self.df.empty:
+            # In case there's no data, return a minimal chart:
+            chart = alt.Chart(pd.DataFrame({"No Data": []})).mark_text(text="No data to show.")
+            return chart.to_dict()
+
+        max_turn = int(self.df["turn"].max())
+        turn_sort = [str(i) for i in range(1, max_turn + 1)]
+
+        chart = (
+            alt.Chart(self.df)
+            .transform_joinaggregate(
+                total_simulations='sum(frequency)',
+                groupby=['turn_label']
+            )
+            .transform_calculate(
+                percent='datum.frequency / datum.total_simulations'
+            )
+            .transform_filter("datum.dead_spells > 0")  # ignore 0 dead spells
+            .mark_bar()
+            .encode(
+                x=alt.X(
+                    "turn_label:N",
+                    title="Turn number",
+                    scale=alt.Scale(domain=turn_sort)
+                ),
+                y=alt.Y(
+                    "percent:Q",
+                    title="Percent of simulations",
+                    scale=alt.Scale(domain=[0, 1]),
+                    axis=alt.Axis(format='%')
+                ),
+                color=alt.Color(
+                    "dead_spells:O",
+                    title="Dead spells",
+                    scale=alt.Scale(scheme="magma", reverse=False)
+                ),
+                order=alt.Order("dead_spells:Q", sort="descending")
+            )
+            .properties(
+                width=plot_width,
+                height=plot_height
+            )
+            # Transparent chart background + no border
+            .configure(background='transparent')
+            .configure_view(stroke=None)
+        )
+        return chart.to_dict()
+
+
+class BestColorChart(BaseChart):
+    """
+    Creates a line chart showing how often switching a land to each color is optimal.
+    """
+
+    def render_spec(self) -> dict:
+        plot_width = 600
+        plot_height = 300
+
+        if self.df.empty:
+            # In case there's no data, return a minimal chart:
+            chart = alt.Chart(pd.DataFrame({"No Data": []})).mark_text(text="No data to show.")
+            return chart.to_dict()
+
+        max_turn = int(self.df["turn"].max())
+        turn_sort = [str(i) for i in range(1, max_turn + 1)]
+
+        # We'll rename columns like pct_optimal_W -> W
+        rename_map = {f"pct_optimal_{c}": c for c in CANONICAL_COLORS}
+
+        df_colordist = self.df.copy()
+        df_colordist.rename(columns=rename_map, inplace=True)
+
+        chart = (
+            alt.Chart(df_colordist)
+            .transform_fold(
+                CANONICAL_COLORS,
+                as_=["color_type", "pct"]
+            )
+            .mark_line()
+            .encode(
+                x=alt.X(
+                    "turn_label:N",
+                    scale=alt.Scale(domain=turn_sort),
+                    title="Turn number"
+                ),
+                y=alt.Y(
+                    "pct:Q",
+                    title="Percent of simulations",
+                    axis=alt.Axis(format='%')
+                ),
+                color=alt.Color(
+                    "color_type:N",
+                    scale=alt.Scale(
+                        domain=CANONICAL_COLORS,
+                        range=CANONICAL_COLOR_VALUES
+                    ),
+                    legend=alt.Legend(title="Mana")
+                )
+            )
+            .properties(
+                width=plot_width,
+                height=plot_height
+            )
+            # Transparent chart background + no border
+            .configure(background='transparent')
+            .configure_view(stroke=None)
+        )
+        return chart.to_dict()

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,3 @@
-<!-- ===== ./templates/index.html ===== -->
 <!doctype html>
 <html lang="en">
 
@@ -109,7 +108,7 @@
                     <h5>Charts</h5>
                     <ul>
                         <li><strong>Distribution of Dead Spells:</strong> Bar chart of how often
-                            each number of dead spells occurs.</li>
+                            each number of dead spells occurs (except 0).</li>
                         <li><strong>Best Color to Replace a Land:</strong> How often switching
                             a land to each color is optimal.</li>
                     </ul>
@@ -264,29 +263,9 @@
                     <div class="card-header bg-secondary text-white">
                         Simulation Results
                     </div>
-                    <div class="card-body">
-                        <!-- Alert/error area -->
-                        <div id="alert-area"></div>
-
-                        <!-- Summary stat cards -->
-                        <div id="summary-cards" class="mb-3"></div>
-
-                        <!-- First chart (Distribution) -->
-                        <div class="card mb-3 bg-light">
-                            <div class="card-header fw-bold">
-                                Distribution of Dead Spells
-                            </div>
-                            <div class="card-body" id="distribution-chart"></div>
-                        </div>
-
-                        <!-- Second chart (Best color) -->
-                        <div class="card mb-3 bg-light">
-                            <div class="card-header fw-bold">
-                                Best Color to Replace a Land
-                            </div>
-                            <div class="card-body" id="best-color-chart"></div>
-                        </div>
-
+                    <!-- We'll replace this entire card-body dynamically -->
+                    <div class="card-body" id="results-container">
+                        <!-- Initially empty; we fill with spinner or results at runtime -->
                     </div>
                 </div>
             </div>
@@ -304,29 +283,20 @@
 
     <script>
         function runSimulation() {
+            // Grab our forms and containers
             const form = document.getElementById('simulation-form');
-            const alertArea = document.getElementById('alert-area');
-            const summaryCardsDiv = document.getElementById('summary-cards');
+            const resultsContainer = document.getElementById('results-container');
 
-            // Chart containers
-            const distChartDiv = document.getElementById('distribution-chart');
-            const bestColorChartDiv = document.getElementById('best-color-chart');
-
-            // Clear previous results
-            alertArea.innerHTML = '';
-            summaryCardsDiv.innerHTML = '';
-            distChartDiv.innerHTML = '';
-            bestColorChartDiv.innerHTML = '';
-
-            // Show a spinner or some loading message
-            distChartDiv.innerHTML = `
-                <div class="d-flex align-items-center">
-                    <div class="spinner-border text-primary me-2" role="status">
-                        <span class="visually-hidden">Loading...</span>
-                    </div>
-                    <strong>Running simulation, please wait...</strong>
-                </div>
-            `;
+            // 1) As soon as the user clicks "Run Simulation", clear everything
+            //    and show ONLY the spinner message in #results-container.
+            resultsContainer.innerHTML = `
+        <div class="d-flex align-items-center">
+          <div class="spinner-border text-primary me-2" role="status">
+            <span class="visually-hidden">Loading...</span>
+          </div>
+          <strong>Running simulation, please wait...</strong>
+        </div>
+      `;
 
             // Gather form data
             const formData = new FormData(form);
@@ -344,92 +314,120 @@
                 .then(response => response.json())
                 .then(json => {
                     if (json.error) {
-                        // Display error
-                        distChartDiv.innerHTML = '';
-                        alertArea.innerHTML = `
-                        <div class="alert alert-danger" role="alert">
-                            <strong>Error:</strong> ${json.error}
-                        </div>
-                    `;
+                        // Show error in the results container (no other content)
+                        resultsContainer.innerHTML = `
+            <div class="alert alert-danger" role="alert">
+              <strong>Error:</strong> ${json.error}
+            </div>
+          `;
                     } else {
-                        // Render summary stats
+                        // We have valid results. Rebuild the entire #results-container with:
+                        //  - Statistic cards in a light-grey card
+                        //  - Two separate chart cards, also in a light-grey background
+
                         const stats = json.stats;
                         const pctZeroDead = (stats.pct_turns_zero_dead * 100).toFixed(2);
                         const expDead = stats.expected_dead_per_turn.toFixed(2);
                         const mostColor = stats.most_desired_color;
                         const leastColor = stats.least_desired_color;
 
-                        // Build a row of small "statistic cards"
-                        let cardsHTML = `
-                      <div class="row row-cols-2 row-cols-md-4 g-2">
-                        <div class="col">
-                          <div class="card text-center border-0 bg-light">
-                            <div class="card-body p-2">
-                              <h6 class="card-title mb-1" style="font-size:0.85rem;">
-                                % of turns with 0 dead spells
-                              </h6>
-                              <p class="card-text fw-bold" style="font-size:1rem;">
-                                ${pctZeroDead}%
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="col">
-                          <div class="card text-center border-0 bg-light">
-                            <div class="card-body p-2">
-                              <h6 class="card-title mb-1" style="font-size:0.85rem;">
-                                Expected dead spells per turn
-                              </h6>
-                              <p class="card-text fw-bold" style="font-size:1rem;">
-                                ${expDead}
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="col">
-                          <div class="card text-center border-0 bg-light">
-                            <div class="card-body p-2">
-                              <h6 class="card-title mb-1" style="font-size:0.85rem;">
-                                Most desired pip color
-                              </h6>
-                              <p class="card-text fw-bold" style="font-size:1rem;">
-                                ${mostColor}
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="col">
-                          <div class="card text-center border-0 bg-light">
-                            <div class="card-body p-2">
-                              <h6 class="card-title mb-1" style="font-size:0.85rem;">
-                                Least desired pip color
-                              </h6>
-                              <p class="card-text fw-bold" style="font-size:1rem;">
-                                ${leastColor}
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    `;
-                        summaryCardsDiv.innerHTML = cardsHTML;
+                        // Build the HTML for our "statistic cards"
+                        const statCardsHTML = `
+            <div class="row row-cols-2 row-cols-md-4 g-2">
+              <div class="col">
+                <div class="card text-center border-0 bg-light">
+                  <div class="card-body p-2">
+                    <h6 class="card-title mb-1" style="font-size:0.85rem;">
+                      % of turns with 0 dead spells
+                    </h6>
+                    <p class="card-text fw-bold" style="font-size:1rem;">
+                      ${pctZeroDead}%
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="col">
+                <div class="card text-center border-0 bg-light">
+                  <div class="card-body p-2">
+                    <h6 class="card-title mb-1" style="font-size:0.85rem;">
+                      Expected dead spells per turn
+                    </h6>
+                    <p class="card-text fw-bold" style="font-size:1rem;">
+                      ${expDead}
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="col">
+                <div class="card text-center border-0 bg-light">
+                  <div class="card-body p-2">
+                    <h6 class="card-title mb-1" style="font-size:0.85rem;">
+                      Most desired pip color
+                    </h6>
+                    <p class="card-text fw-bold" style="font-size:1rem;">
+                      ${mostColor}
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="col">
+                <div class="card text-center border-0 bg-light">
+                  <div class="card-body p-2">
+                    <h6 class="card-title mb-1" style="font-size:0.85rem;">
+                      Least desired pip color
+                    </h6>
+                    <p class="card-text fw-bold" style="font-size:1rem;">
+                      ${leastColor}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          `;
 
-                        // Clear the spinner
-                        distChartDiv.innerHTML = '';
-                        bestColorChartDiv.innerHTML = '';
+                        // 2) Now populate the results container with:
+                        //    - a card for the stats
+                        //    - a card for the Distribution chart
+                        //    - a card for the Best Color chart
+                        resultsContainer.innerHTML = `
+            <!-- Stats card -->
+            <div class="card mb-3 bg-light">
+              <div class="card-header fw-bold">
+                Statistics
+              </div>
+              <div class="card-body" id="summary-cards">
+                ${statCardsHTML}
+              </div>
+            </div>
 
-                        // Render the two charts in separate containers
+            <!-- First chart card -->
+            <div class="card mb-3 bg-light">
+              <div class="card-header fw-bold">
+                Distribution of Dead Spells
+              </div>
+              <div class="card-body" id="distribution-chart"></div>
+            </div>
+
+            <!-- Second chart card -->
+            <div class="card mb-3 bg-light">
+              <div class="card-header fw-bold">
+                Best Color to Replace a Land
+              </div>
+              <div class="card-body" id="best-color-chart"></div>
+            </div>
+          `;
+
+                        // 3) Embed the two charts using Vega-Embed
                         vegaEmbed('#distribution-chart', json.dist_chart_spec);
                         vegaEmbed('#best-color-chart', json.best_color_chart_spec);
                     }
                 })
                 .catch(error => {
-                    distChartDiv.innerHTML = '';
-                    alertArea.innerHTML = `
-                    <div class="alert alert-danger" role="alert">
-                        <strong>Error:</strong> ${error}
-                    </div>
-                `;
+                    resultsContainer.innerHTML = `
+          <div class="alert alert-danger" role="alert">
+            <strong>Error:</strong> ${error}
+          </div>
+        `;
                 });
         }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <title>MTG "Got Pips" Mana Simulator</title>
+    <title>Mathamagic Mana Simulator</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -15,6 +15,12 @@
     <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
 
     <style>
+        /* Custom dark blue background color for the navbar & footer */
+        .bg-custom {
+            background-color: #003366 !important;
+            /* Adjust this hex if you'd like a lighter/darker shade */
+        }
+
         body {
             background-color: #f8f9fa;
             margin-bottom: 60px;
@@ -47,11 +53,11 @@
 </head>
 
 <body>
-    <!-- Sticky Navbar -->
-    <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm sticky-top mb-3">
+    <!-- Sticky Navbar with dark blue background -->
+    <nav class="navbar navbar-expand-lg navbar-dark bg-custom shadow-sm sticky-top mb-3">
         <div class="container-fluid">
             <a class="navbar-brand" href="#">
-                MTG "Got Pips" Mana Simulator
+                Mathamagic Mana Simulator
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent"
                 aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -59,17 +65,17 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-                    <!-- Methodology modal trigger -->
+                    <!-- methodology modal trigger -->
                     <li class="nav-item me-2">
-                        <button class="btn btn-outline-secondary my-2 my-sm-0" type="button" data-bs-toggle="modal"
+                        <button class="btn btn-outline-light my-2 my-sm-0" type="button" data-bs-toggle="modal"
                             data-bs-target="#aboutModal">
                             Methodology
                         </button>
                     </li>
-                    <!-- Run Simulation trigger -->
+                    <!-- run simulation trigger -->
                     <li class="nav-item">
                         <button id="runSimulationHeader" class="btn btn-primary my-2 my-sm-0" type="button">
-                            Run Simulation
+                            Run simulation
                         </button>
                     </li>
                 </ul>
@@ -77,7 +83,7 @@
         </div>
     </nav>
 
-    <!-- Modal: Methodology -->
+    <!-- modal: methodology -->
     <div class="modal fade" id="aboutModal" tabindex="-1" aria-labelledby="aboutModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
@@ -87,7 +93,7 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    <h5>Simulation Methodology</h5>
+                    <h5>Simulation methodology</h5>
                     <p>This simulator models a Magic: The Gathering scenario where your deck
                         contains a mix of spells and mana cards. For each simulation:</p>
                     <ul>
@@ -96,7 +102,7 @@
                         <li>We also track which single-color pip helps reduce dead spells most.</li>
                     </ul>
 
-                    <h5>Uncolored Mana &amp; Numeric Prefixes</h5>
+                    <h5>Uncolored mana &amp; numeric prefixes</h5>
                     <p>Use numeric prefixes and <code>*</code> for generic mana. Examples:</p>
                     <ul>
                         <li><code>U</code> = requires 1 blue pip</li>
@@ -107,9 +113,9 @@
 
                     <h5>Charts</h5>
                     <ul>
-                        <li><strong>Distribution of Dead Spells:</strong> Bar chart of how often
+                        <li><strong>Distribution of dead spells:</strong> Bar chart of how often
                             each number of dead spells occurs (except 0).</li>
-                        <li><strong>Best Color to Replace a Land:</strong> How often switching
+                        <li><strong>Best color to replace a land:</strong> How often switching
                             a land to each color is optimal.</li>
                     </ul>
                 </div>
@@ -121,23 +127,23 @@
             </div>
         </div>
     </div>
-    <!-- End Methodology Modal -->
+    <!-- end methodology modal -->
 
-    <!-- Main container -->
+    <!-- main container -->
     <div class="container-fluid py-3">
-        <!-- Two-column row: left = settings, right = results -->
+        <!-- two-column row: left = settings, right = results -->
         <div class="row">
-            <!-- Left (Narrow) Column: Simulation Settings -->
+            <!-- left (narrow) column: simulation settings -->
             <div class="col-md-3 mb-4">
                 <div class="card">
                     <div class="card-header bg-primary text-white">
-                        Simulation Settings
+                        Simulation settings
                     </div>
                     <div class="card-body">
                         <form id="simulation-form">
                             <div class="mb-3">
                                 <label for="deck_size" class="form-label">
-                                    Deck Size
+                                    Deck size
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
                                         title="Total cards in your deck (including spells, mana, filler).">
                                         ?
@@ -149,7 +155,7 @@
 
                             <div class="mb-3">
                                 <label for="hand_size" class="form-label">
-                                    Initial Hand Size
+                                    Initial hand size
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
                                         title="Number of cards in your opening hand.">
                                         ?
@@ -161,7 +167,7 @@
 
                             <div class="mb-3">
                                 <label for="draws" class="form-label">
-                                    Number of Draw Steps
+                                    Number of draw steps
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
                                         title="Number of additional turns to simulate; you draw 1 card each turn.">
                                         ?
@@ -172,7 +178,7 @@
 
                             <div class="mb-3">
                                 <label for="simulations" class="form-label">
-                                    Number of Simulations
+                                    Number of simulations
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
                                         title="Number of simulated trials (higher = more accurate).">
                                         ?
@@ -184,7 +190,7 @@
 
                             <div class="mb-3">
                                 <label for="seed" class="form-label">
-                                    Random Seed
+                                    Random seed
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
                                         title="Set this for reproducible results.">
                                         ?
@@ -195,7 +201,7 @@
 
                             <div class="mb-3">
                                 <label for="on_play_or_draw" class="form-label">
-                                    On the Play or Draw
+                                    On the play or draw
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
                                         title="Affects how many lands you've been able to play by each turn.">
                                         ?
@@ -257,11 +263,11 @@
                 </div>
             </div>
 
-            <!-- Right (Wider) Column: Results -->
+            <!-- right (wider) column: results -->
             <div class="col-md-9">
                 <div class="card">
                     <div class="card-header bg-secondary text-white">
-                        Simulation Results
+                        Simulation results
                     </div>
                     <!-- We'll replace this entire card-body dynamically -->
                     <div class="card-body" id="results-container">
@@ -272,9 +278,9 @@
         </div>
     </div>
 
-    <!-- Optional Footer -->
-    <footer class="fixed-bottom bg-light text-center p-2">
-        <small class="text-muted">© 2025 Magic Tools, Inc.</small>
+    <!-- footer with dark blue background -->
+    <footer class="fixed-bottom bg-custom text-white text-center p-2">
+        <small class="text-white-50">© 2025 Mathamagic, Inc.</small>
     </footer>
 
     <!-- Bootstrap JS (Popper + Bootstrap) -->
@@ -283,12 +289,11 @@
 
     <script>
         function runSimulation() {
-            // Grab our forms and containers
+            // Grab our form and the results container
             const form = document.getElementById('simulation-form');
             const resultsContainer = document.getElementById('results-container');
 
-            // 1) As soon as the user clicks "Run Simulation", clear everything
-            //    and show ONLY the spinner message in #results-container.
+            // Show ONLY the spinner message in #results-container while we wait
             resultsContainer.innerHTML = `
         <div class="d-flex align-items-center">
           <div class="spinner-border text-primary me-2" role="status">
@@ -314,24 +319,21 @@
                 .then(response => response.json())
                 .then(json => {
                     if (json.error) {
-                        // Show error in the results container (no other content)
+                        // Show error (only) in the results container
                         resultsContainer.innerHTML = `
             <div class="alert alert-danger" role="alert">
               <strong>Error:</strong> ${json.error}
             </div>
           `;
                     } else {
-                        // We have valid results. Rebuild the entire #results-container with:
-                        //  - Statistic cards in a light-grey card
-                        //  - Two separate chart cards, also in a light-grey background
-
+                        // We have valid results. Rebuild the #results-container
                         const stats = json.stats;
                         const pctZeroDead = (stats.pct_turns_zero_dead * 100).toFixed(2);
                         const expDead = stats.expected_dead_per_turn.toFixed(2);
                         const mostColor = stats.most_desired_color;
                         const leastColor = stats.least_desired_color;
 
-                        // Build the HTML for our "statistic cards"
+                        // Build stat cards
                         const statCardsHTML = `
             <div class="row row-cols-2 row-cols-md-4 g-2">
               <div class="col">
@@ -385,12 +387,8 @@
             </div>
           `;
 
-                        // 2) Now populate the results container with:
-                        //    - a card for the stats
-                        //    - a card for the Distribution chart
-                        //    - a card for the Best Color chart
                         resultsContainer.innerHTML = `
-            <!-- Stats card -->
+            <!-- stats card -->
             <div class="card mb-3 bg-light">
               <div class="card-header fw-bold">
                 Statistics
@@ -400,24 +398,24 @@
               </div>
             </div>
 
-            <!-- First chart card -->
+            <!-- first chart card -->
             <div class="card mb-3 bg-light">
               <div class="card-header fw-bold">
-                Distribution of Dead Spells
+                Distribution of dead spells
               </div>
               <div class="card-body" id="distribution-chart"></div>
             </div>
 
-            <!-- Second chart card -->
+            <!-- second chart card -->
             <div class="card mb-3 bg-light">
               <div class="card-header fw-bold">
-                Best Color to Replace a Land
+                Best color to replace a land
               </div>
               <div class="card-body" id="best-color-chart"></div>
             </div>
           `;
 
-                        // 3) Embed the two charts using Vega-Embed
+                        // Render the two charts
                         vegaEmbed('#distribution-chart', json.dist_chart_spec);
                         vegaEmbed('#best-color-chart', json.best_color_chart_spec);
                     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,3 +1,4 @@
+<!-- ===== ./templates/index.html ===== -->
 <!doctype html>
 <html lang="en">
 
@@ -7,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Bootstrap 5 CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- Vega, Vega-Lite, vega-embed libraries -->
     <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
@@ -23,14 +24,13 @@
         /* Make the navbar sticky at the top on scroll */
         .navbar.sticky-top {
             z-index: 999;
-            /* ensures navbar stays above other elements while scrolling */
+            /* ensures navbar stays above other elements */
         }
 
         .tooltip-help {
             color: #0d6efd;
             font-weight: bold;
             cursor: pointer;
-            /* pointer instead of 'help' */
         }
 
         textarea.form-control {
@@ -39,7 +39,8 @@
         }
 
         /* The chart container: ensure no horizontal overflow, no border by default */
-        #chart-result {
+        #distribution-chart,
+        #best-color-chart {
             overflow-x: auto;
             max-width: 100%;
         }
@@ -83,19 +84,20 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="aboutModalLabel">Methodology</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+                    </button>
                 </div>
                 <div class="modal-body">
                     <h5>Simulation Methodology</h5>
-                    <p>This simulator models a Magic: The Gathering scenario where your deck contains a mix of spells
-                        and mana cards. For each simulation:
-                    </p>
+                    <p>This simulator models a Magic: The Gathering scenario where your deck
+                        contains a mix of spells and mana cards. For each simulation:</p>
                     <ul>
                         <li>The deck is shuffled, then cards are drawn over several turns.</li>
-                        <li>"Dead" spells are spells you cannot cast (insufficient mana sources).</li>
-                        <li>We also track which single-color pip helps the most to reduce dead spells.</li>
+                        <li>"Dead" spells are spells you cannot cast.</li>
+                        <li>We also track which single-color pip helps reduce dead spells most.</li>
                     </ul>
-                    <h5>Uncolored Mana & Numeric Prefixes</h5>
+
+                    <h5>Uncolored Mana &amp; Numeric Prefixes</h5>
                     <p>Use numeric prefixes and <code>*</code> for generic mana. Examples:</p>
                     <ul>
                         <li><code>U</code> = requires 1 blue pip</li>
@@ -103,12 +105,13 @@
                         <li><code>4*</code> = requires 4 generic mana</li>
                         <li><code>4*U2W</code> = requires 4 generic mana, 1 blue, 2 white</li>
                     </ul>
+
                     <h5>Charts</h5>
                     <ul>
-                        <li><strong>Top chart:</strong> Bar chart of how often each number of dead spells occurs per
-                            draw step.</li>
-                        <li><strong>Bottom chart:</strong> Line chart showing how often switching a land to each color
-                            is optimal.</li>
+                        <li><strong>Distribution of Dead Spells:</strong> Bar chart of how often
+                            each number of dead spells occurs.</li>
+                        <li><strong>Best Color to Replace a Land:</strong> How often switching
+                            a land to each color is optimal.</li>
                     </ul>
                 </div>
                 <div class="modal-footer">
@@ -137,7 +140,9 @@
                                 <label for="deck_size" class="form-label">
                                     Deck Size
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Total cards in your deck, including spells, mana, and filler.">?</span>
+                                        title="Total cards in your deck (including spells, mana, filler).">
+                                        ?
+                                    </span>
                                 </label>
                                 <input type="number" class="form-control" id="deck_size" name="deck_size" value="40"
                                     required>
@@ -147,7 +152,9 @@
                                 <label for="hand_size" class="form-label">
                                     Initial Hand Size
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Number of cards in your opening hand.">?</span>
+                                        title="Number of cards in your opening hand.">
+                                        ?
+                                    </span>
                                 </label>
                                 <input type="number" class="form-control" id="hand_size" name="hand_size" value="7"
                                     required>
@@ -157,7 +164,9 @@
                                 <label for="draws" class="form-label">
                                     Number of Draw Steps
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Number of additional turns to simulate; you draw 1 card each turn.">?</span>
+                                        title="Number of additional turns to simulate; you draw 1 card each turn.">
+                                        ?
+                                    </span>
                                 </label>
                                 <input type="number" class="form-control" id="draws" name="draws" value="10" required>
                             </div>
@@ -166,7 +175,9 @@
                                 <label for="simulations" class="form-label">
                                     Number of Simulations
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Number of simulated trials (higher = more accurate).">?</span>
+                                        title="Number of simulated trials (higher = more accurate).">
+                                        ?
+                                    </span>
                                 </label>
                                 <input type="number" class="form-control" id="simulations" name="simulations"
                                     value="1000" required>
@@ -176,7 +187,9 @@
                                 <label for="seed" class="form-label">
                                     Random Seed
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Set this for reproducible results.">?</span>
+                                        title="Set this for reproducible results.">
+                                        ?
+                                    </span>
                                 </label>
                                 <input type="number" class="form-control" id="seed" name="seed" value="42" required>
                             </div>
@@ -185,7 +198,9 @@
                                 <label for="on_play_or_draw" class="form-label">
                                     On the Play or Draw
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Affects how many lands you've been able to play by each turn.">?</span>
+                                        title="Affects how many lands you've been able to play by each turn.">
+                                        ?
+                                    </span>
                                 </label>
                                 <select id="on_play_or_draw" name="on_play_or_draw" class="form-select">
                                     <option value="play" selected>Play</option>
@@ -197,7 +212,9 @@
                                 <label for="spells_json" class="form-label">
                                     Spells (JSON)
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Map of spell costs (e.g. 'U', '4*U2W') to the quantity in your deck.">?</span>
+                                        title="Map of spell costs (e.g. 'U', '4*U2W') to the quantity in your deck.">
+                                        ?
+                                    </span>
                                 </label>
                                 <textarea id="spells_json" name="spells_json" class="form-control" rows="5">{
     "G": 2,
@@ -224,7 +241,9 @@
                                 <label for="mana_json" class="form-label">
                                     Mana (JSON)
                                     <span class="tooltip-help" data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Map of mana source types (e.g. 'U', 'UW') to their count.">?</span>
+                                        title="Map of mana source types (e.g. 'U', 'UW') to their count.">
+                                        ?
+                                    </span>
                                 </label>
                                 <textarea id="mana_json" name="mana_json" class="form-control" rows="5">{
     "G": 7,
@@ -249,11 +268,25 @@
                         <!-- Alert/error area -->
                         <div id="alert-area"></div>
 
-                        <!-- Cards of summary stats (above chart) -->
+                        <!-- Summary stat cards -->
                         <div id="summary-cards" class="mb-3"></div>
 
-                        <!-- Chart container with no border -->
-                        <div id="chart-result" class="mt-2"></div>
+                        <!-- First chart (Distribution) -->
+                        <div class="card mb-3 bg-light">
+                            <div class="card-header fw-bold">
+                                Distribution of Dead Spells
+                            </div>
+                            <div class="card-body" id="distribution-chart"></div>
+                        </div>
+
+                        <!-- Second chart (Best color) -->
+                        <div class="card mb-3 bg-light">
+                            <div class="card-header fw-bold">
+                                Best Color to Replace a Land
+                            </div>
+                            <div class="card-body" id="best-color-chart"></div>
+                        </div>
+
                     </div>
                 </div>
             </div>
@@ -266,29 +299,34 @@
     </footer>
 
     <!-- Bootstrap JS (Popper + Bootstrap) -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js">
+    </script>
 
     <script>
         function runSimulation() {
             const form = document.getElementById('simulation-form');
-            const chartDiv = document.getElementById('chart-result');
-            const summaryCardsDiv = document.getElementById('summary-cards');
             const alertArea = document.getElementById('alert-area');
+            const summaryCardsDiv = document.getElementById('summary-cards');
+
+            // Chart containers
+            const distChartDiv = document.getElementById('distribution-chart');
+            const bestColorChartDiv = document.getElementById('best-color-chart');
 
             // Clear previous results
-            chartDiv.innerHTML = '';
-            summaryCardsDiv.innerHTML = '';
             alertArea.innerHTML = '';
+            summaryCardsDiv.innerHTML = '';
+            distChartDiv.innerHTML = '';
+            bestColorChartDiv.innerHTML = '';
 
-            // Show a spinner in the chart area while processing
-            chartDiv.innerHTML = `
-        <div class="d-flex align-items-center">
-          <div class="spinner-border text-primary me-2" role="status">
-            <span class="visually-hidden">Loading...</span>
-          </div>
-          <strong>Running simulation, please wait...</strong>
-        </div>
-      `;
+            // Show a spinner or some loading message
+            distChartDiv.innerHTML = `
+                <div class="d-flex align-items-center">
+                    <div class="spinner-border text-primary me-2" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                    <strong>Running simulation, please wait...</strong>
+                </div>
+            `;
 
             // Gather form data
             const formData = new FormData(form);
@@ -307,99 +345,110 @@
                 .then(json => {
                     if (json.error) {
                         // Display error
-                        chartDiv.innerHTML = '';
+                        distChartDiv.innerHTML = '';
                         alertArea.innerHTML = `
-              <div class="alert alert-danger" role="alert">
-                <strong>Error:</strong> ${json.error}
-              </div>
-            `;
+                        <div class="alert alert-danger" role="alert">
+                            <strong>Error:</strong> ${json.error}
+                        </div>
+                    `;
                     } else {
+                        // Render summary stats
                         const stats = json.stats;
+                        const pctZeroDead = (stats.pct_turns_zero_dead * 100).toFixed(2);
+                        const expDead = stats.expected_dead_per_turn.toFixed(2);
+                        const mostColor = stats.most_desired_color;
+                        const leastColor = stats.least_desired_color;
 
                         // Build a row of small "statistic cards"
-                        // We'll use 4 columns on medium/large screens, 2 columns on smaller screens
                         let cardsHTML = `
-              <div class="row row-cols-2 row-cols-md-4 g-2">
-                <div class="col">
-                  <div class="card text-center border-0 bg-light">
-                    <div class="card-body p-2">
-                      <h6 class="card-title mb-1" style="font-size: 0.85rem;">
-                        % of turns with 0 dead spells
-                      </h6>
-                      <p class="card-text fw-bold" style="font-size: 1rem;">
-                        ${(stats.pct_turns_zero_dead * 100).toFixed(2)}%
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div class="col">
-                  <div class="card text-center border-0 bg-light">
-                    <div class="card-body p-2">
-                      <h6 class="card-title mb-1" style="font-size: 0.85rem;">
-                        Expected dead spells per turn
-                      </h6>
-                      <p class="card-text fw-bold" style="font-size: 1rem;">
-                        ${stats.expected_dead_per_turn.toFixed(2)}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div class="col">
-                  <div class="card text-center border-0 bg-light">
-                    <div class="card-body p-2">
-                      <h6 class="card-title mb-1" style="font-size: 0.85rem;">
-                        Most desired pip color
-                      </h6>
-                      <p class="card-text fw-bold" style="font-size: 1rem;">
-                        ${stats.most_desired_color}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div class="col">
-                  <div class="card text-center border-0 bg-light">
-                    <div class="card-body p-2">
-                      <h6 class="card-title mb-1" style="font-size: 0.85rem;">
-                        Least desired pip color
-                      </h6>
-                      <p class="card-text fw-bold" style="font-size: 1rem;">
-                        ${stats.least_desired_color}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            `;
-
+                      <div class="row row-cols-2 row-cols-md-4 g-2">
+                        <div class="col">
+                          <div class="card text-center border-0 bg-light">
+                            <div class="card-body p-2">
+                              <h6 class="card-title mb-1" style="font-size:0.85rem;">
+                                % of turns with 0 dead spells
+                              </h6>
+                              <p class="card-text fw-bold" style="font-size:1rem;">
+                                ${pctZeroDead}%
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col">
+                          <div class="card text-center border-0 bg-light">
+                            <div class="card-body p-2">
+                              <h6 class="card-title mb-1" style="font-size:0.85rem;">
+                                Expected dead spells per turn
+                              </h6>
+                              <p class="card-text fw-bold" style="font-size:1rem;">
+                                ${expDead}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col">
+                          <div class="card text-center border-0 bg-light">
+                            <div class="card-body p-2">
+                              <h6 class="card-title mb-1" style="font-size:0.85rem;">
+                                Most desired pip color
+                              </h6>
+                              <p class="card-text fw-bold" style="font-size:1rem;">
+                                ${mostColor}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col">
+                          <div class="card text-center border-0 bg-light">
+                            <div class="card-body p-2">
+                              <h6 class="card-title mb-1" style="font-size:0.85rem;">
+                                Least desired pip color
+                              </h6>
+                              <p class="card-text fw-bold" style="font-size:1rem;">
+                                ${leastColor}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    `;
                         summaryCardsDiv.innerHTML = cardsHTML;
 
-                        // Render the charts
-                        vegaEmbed('#chart-result', json.chart_spec);
+                        // Clear the spinner
+                        distChartDiv.innerHTML = '';
+                        bestColorChartDiv.innerHTML = '';
+
+                        // Render the two charts in separate containers
+                        vegaEmbed('#distribution-chart', json.dist_chart_spec);
+                        vegaEmbed('#best-color-chart', json.best_color_chart_spec);
                     }
                 })
                 .catch(error => {
-                    chartDiv.innerHTML = '';
+                    distChartDiv.innerHTML = '';
                     alertArea.innerHTML = `
-            <div class="alert alert-danger" role="alert">
-              <strong>Error:</strong> ${error}
-            </div>
-          `;
+                    <div class="alert alert-danger" role="alert">
+                        <strong>Error:</strong> ${error}
+                    </div>
+                `;
                 });
         }
 
         // Intercept the form submit
-        document.getElementById('simulation-form').addEventListener('submit', function (e) {
-            e.preventDefault();
-            runSimulation();
-        });
+        document.getElementById('simulation-form')
+            .addEventListener('submit', function (e) {
+                e.preventDefault();
+                runSimulation();
+            });
 
         // "Run Simulation" button in navbar
-        document.getElementById('runSimulationHeader').addEventListener('click', runSimulation);
+        document.getElementById('runSimulationHeader')
+            .addEventListener('click', runSimulation);
 
         // Initialize all Bootstrap 5 tooltips
-        document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => {
-            new bootstrap.Tooltip(el);
-        });
+        document.querySelectorAll('[data-bs-toggle="tooltip"]')
+            .forEach((el) => {
+                new bootstrap.Tooltip(el);
+            });
     </script>
 </body>
 


### PR DESCRIPTION
The visualizations are now split into their own cards, plus more formatting changes:

<img width="1724" alt="image" src="https://github.com/user-attachments/assets/cd0a3ecd-e92b-4352-878a-a629f59a79f3" />

Conversation here: https://chatgpt.com/share/67c99905-3400-8003-9425-74c269d68d19