### PR TITLE
Sim form help

### DIFF
--- a/templates/help_modals.html
+++ b/templates/help_modals.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<!-- Modal for Set -->
+<div class="modal fade" id="helpSet" tabindex="-1" aria-labelledby="helpSetLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpSetLabel">Set</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Select the card set to use in the simulation. Different sets may have different card data and rules.
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal for Play or Draw -->
+<div class="modal fade" id="helpOnPlayOrDraw" tabindex="-1" aria-labelledby="helpOnPlayOrDrawLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpOnPlayOrDrawLabel">Play or Draw</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Choose whether you are on the play or on the draw. This affects the simulation's draw order and
+                available mana.
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal for Deck List -->
+<div class="modal fade" id="helpDeckList" tabindex="-1" aria-labelledby="helpDeckListLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpDeckListLabel">Deck List</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Paste your deck list here. It should include a "Deck" section and optionally a "Sideboard" section
+                (which will be ignored).
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal for Deck Size -->
+<div class="modal fade" id="helpDeckSize" tabindex="-1" aria-labelledby="helpDeckSizeLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpDeckSizeLabel">Deck Size</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Specify the total number of cards in the deck, including filler cards. This determines how many cards
+                are in your simulated deck.
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal for Initial Hand Size -->
+<div class="modal fade" id="helpHandSize" tabindex="-1" aria-labelledby="helpHandSizeLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpHandSizeLabel">Initial Hand Size</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Enter the number of cards drawn in your opening hand.
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal for Number of Draw Steps -->
+<div class="modal fade" id="helpDraws" tabindex="-1" aria-labelledby="helpDrawsLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpDrawsLabel">Number of Draw Steps</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                This is the number of turns (or draw steps) to simulate beyond the initial hand.
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal for Number of Simulations -->
+<div class="modal fade" id="helpSimulations" tabindex="-1" aria-labelledby="helpSimulationsLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpSimulationsLabel">Number of Simulations</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Set how many times the simulation will run. More simulations provide smoother statistics but take
+                longer.
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal for Random Seed -->
+<div class="modal fade" id="helpSeed" tabindex="-1" aria-labelledby="helpSeedLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpSeedLabel">Random Seed</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Enter a number to seed the random number generator. This makes simulation runs reproducible.
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/help_modals.html
+++ b/templates/help_modals.html
@@ -8,7 +8,15 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                Select the card set to use in the simulation. Different sets may have different card data and rules.
+                <p>
+                    Select the card set to use in the simulation.
+                </p>
+                <p>
+                    Note that the only currently supported set is DFT (Aetherdrift).
+                    I plan to add more sets in the future, but it requires manually
+                    coding the mana costs / production capabilities of each card in
+                    the set.
+                </p>
             </div>
         </div>
     </div>
@@ -19,7 +27,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="helpOnPlayOrDrawLabel">Play or Draw</h5>
+                <h5 class="modal-title" id="helpOnPlayOrDrawLabel">Play or draw</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
@@ -35,12 +43,24 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="helpDeckListLabel">Deck List</h5>
+                <h5 class="modal-title" id="helpDeckListLabel">Deck list</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                Paste your deck list here. It should include a "Deck" section and optionally a "Sideboard" section
-                (which will be ignored).
+                <p>
+                    Paste your deck list here. It should include a "Deck" section and optionally a "Sideboard" section
+                    (which will be ignored for this application).
+                </p>
+                <p>
+                    To get your deck list from 17lands, click on the "Deck Export" button from the deck view and
+                    select "Copy as plain text" and then paste it here.
+                </p>
+                <p>
+                    To get your deck list from MTG Arena, first save the deck to your decks,
+                    then hover over the deck in the "Decks" section, and click on the "Export"
+                    icon at the bottom of the screen, which will copy the deck to your clipboard
+                    so that you can paste it here.
+                </p>
             </div>
         </div>
     </div>
@@ -51,12 +71,16 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="helpDeckSizeLabel">Deck Size</h5>
+                <h5 class="modal-title" id="helpDeckSizeLabel">Deck size</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                Specify the total number of cards in the deck, including filler cards. This determines how many cards
-                are in your simulated deck.
+                <p>
+                    Specify the total number of cards in the deck.
+                </p>
+                <p>
+                    This is used to validate that your deck list is complete.
+                </p>
             </div>
         </div>
     </div>
@@ -67,7 +91,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="helpHandSizeLabel">Initial Hand Size</h5>
+                <h5 class="modal-title" id="helpHandSizeLabel">Initial hand size</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
@@ -82,11 +106,19 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="helpDrawsLabel">Number of Draw Steps</h5>
+                <h5 class="modal-title" id="helpDrawsLabel">Number of turns</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                This is the number of turns (or draw steps) to simulate beyond the initial hand.
+                <p>
+                    This is the number of turns (or draw steps) to simulate beyond the initial hand.
+                </p>
+                <p>
+                    For example, if you set this to 10, the simulation will draw 10 additional cards after the initial
+                    hand. In general, your mana consumption matters the most in the early draw steps,
+                    and so 10 is a reasonable starting place. If you set this to a larger number, the
+                    simulation will take longer to run.
+                </p>
             </div>
         </div>
     </div>
@@ -97,7 +129,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="helpSimulationsLabel">Number of Simulations</h5>
+                <h5 class="modal-title" id="helpSimulationsLabel">Number of simulations</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
@@ -113,7 +145,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="helpSeedLabel">Random Seed</h5>
+                <h5 class="modal-title" id="helpSeedLabel">Random seed</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">

--- a/templates/index.html
+++ b/templates/index.html
@@ -157,7 +157,7 @@
                 <div>
                     <button class="btn btn-outline-light btn-sm" type="button" data-bs-toggle="modal"
                         data-bs-target="#aboutModal">
-                        About
+                        Methodology
                     </button>
                 </div>
                 <div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,10 +76,6 @@
         .help-icon {
             color: grey;
             background-color: white;
-            border: 1px solid grey;
-            border-radius: 50%;
-            width: 18px;
-            height: 18px;
             display: inline-flex;
             align-items: center;
             justify-content: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,14 +74,10 @@
 
         /* New styling for the help icon */
         .help-icon {
-            color: grey;
+            color: #0d6efd;
             background-color: white;
             display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 0.8rem;
-            text-decoration: none;
-            margin-left: 4px;
+            margin-left: 1px;
         }
     </style>
 </head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -71,6 +71,22 @@
             overflow-x: auto;
             max-width: 100%;
         }
+
+        /* New styling for the help icon */
+        .help-icon {
+            color: grey;
+            background-color: white;
+            border: 1px solid grey;
+            border-radius: 50%;
+            width: 18px;
+            height: 18px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.8rem;
+            text-decoration: none;
+            margin-left: 4px;
+        }
     </style>
 </head>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,12 +97,12 @@
                     <li class="nav-item me-2">
                         <button class="btn btn-outline-light my-2 my-sm-0" type="button" data-bs-toggle="modal"
                             data-bs-target="#aboutModal">
-                            Methodology
+                            About
                         </button>
                     </li>
                     <li class="nav-item">
                         <button id="runSimulationHeader" class="btn btn-primary my-2 my-sm-0" type="button">
-                            Run simulation
+                            Run
                         </button>
                     </li>
                 </ul>
@@ -114,7 +114,7 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="aboutModalLabel">Methodology</h5>
+                    <h5 class="modal-title" id="aboutModalLabel">About</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">

--- a/templates/index.html
+++ b/templates/index.html
@@ -94,12 +94,7 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-                    <li class="nav-item me-2">
-                        <button class="btn btn-outline-light my-2 my-sm-0" type="button" data-bs-toggle="modal"
-                            data-bs-target="#aboutModal">
-                            About
-                        </button>
-                    </li>
+                    <!-- About button removed from navbar -->
                     <li class="nav-item">
                         <button id="runSimulationHeader" class="btn btn-primary my-2 my-sm-0" type="button">
                             Run
@@ -114,7 +109,7 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="aboutModalLabel">About</h5>
+                    <h5 class="modal-title" id="aboutModalLabel">Methodology</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
@@ -156,8 +151,20 @@
         </div>
     </div>
 
-    <footer class="fixed-bottom bg-custom text-white text-center p-2">
-        <small class="text-white-50">© 2025 Mathamagic, Inc.</small>
+    <footer class="fixed-bottom bg-custom text-white p-2">
+        <div class="container-fluid">
+            <div class="d-flex justify-content-between">
+                <div>
+                    <button class="btn btn-outline-light btn-sm" type="button" data-bs-toggle="modal"
+                        data-bs-target="#aboutModal">
+                        About
+                    </button>
+                </div>
+                <div>
+                    <small class="text-white-50">© 2025 Mathamagic, Inc.</small>
+                </div>
+            </div>
+        </div>
     </footer>
 
     {% include "help_modals.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -152,6 +152,8 @@
         <small class="text-white-50">© 2025 Mathamagic, Inc.</small>
     </footer>
 
+    {% include "help_modals.html" %}
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         function runSimulation() {

--- a/templates/simulation_form.html
+++ b/templates/simulation_form.html
@@ -35,23 +35,48 @@
     <div class="collapse" id="advancedCollapse">
         <div class="card-body">
             <div class="mb-3">
-                <label for="deck_size" class="form-label">Deck size</label>
+                <label for="deck_size" class="form-label">
+                    Deck size
+                    <a href="#" data-bs-toggle="modal" data-bs-target="#helpDeckSize" title="Help">
+                        <span class="badge bg-info">?</span>
+                    </a>
+                </label>
                 <input type="number" class="form-control" id="deck_size" name="deck_size" value="40" required>
             </div>
             <div class="mb-3">
-                <label for="hand_size" class="form-label">Initial hand size</label>
+                <label for="hand_size" class="form-label">
+                    Initial hand size
+                    <a href="#" data-bs-toggle="modal" data-bs-target="#helpHandSize" title="Help">
+                        <span class="badge bg-info">?</span>
+                    </a>
+                </label>
                 <input type="number" class="form-control" id="hand_size" name="hand_size" value="7" required>
             </div>
             <div class="mb-3">
-                <label for="draws" class="form-label">Number of draw steps</label>
+                <label for="draws" class="form-label">
+                    Number of draw steps
+                    <a href="#" data-bs-toggle="modal" data-bs-target="#helpDraws" title="Help">
+                        <span class="badge bg-info">?</span>
+                    </a>
+                </label>
                 <input type="number" class="form-control" id="draws" name="draws" value="10" required>
             </div>
             <div class="mb-3">
-                <label for="simulations" class="form-label">Number of simulations</label>
+                <label for="simulations" class="form-label">
+                    Number of simulations
+                    <a href="#" data-bs-toggle="modal" data-bs-target="#helpSimulations" title="Help">
+                        <span class="badge bg-info">?</span>
+                    </a>
+                </label>
                 <input type="number" class="form-control" id="simulations" name="simulations" value="200" required>
             </div>
             <div class="mb-3">
-                <label for="seed" class="form-label">Random seed</label>
+                <label for="seed" class="form-label">
+                    Random seed
+                    <a href="#" data-bs-toggle="modal" data-bs-target="#helpSeed" title="Help">
+                        <span class="badge bg-info">?</span>
+                    </a>
+                </label>
                 <input type="number" class="form-control" id="seed" name="seed" value="42" required>
             </div>
         </div>

--- a/templates/simulation_form.html
+++ b/templates/simulation_form.html
@@ -2,13 +2,23 @@
 <!-- Top row: Simulation Type & On the play or draw -->
 <div class="row mb-3">
     <div class="col">
-        <label for="set" class="form-label">Set</label>
+        <label for="set" class="form-label">
+            Set
+            <a href="#" data-bs-toggle="modal" data-bs-target="#helpSet" title="Help">
+                <span class="help-icon">?</span>
+            </a>
+        </label>
         <select id="set" name="set" class="form-select">
             <option value="DFT" selected>DFT</option>
         </select>
     </div>
     <div class="col">
-        <label for="on_play_or_draw" class="form-label">Play or draw</label>
+        <label for="on_play_or_draw" class="form-label">
+            Play or draw
+            <a href="#" data-bs-toggle="modal" data-bs-target="#helpOnPlayOrDraw" title="Help">
+                <span class="help-icon">?</span>
+            </a>
+        </label>
         <select id="on_play_or_draw" name="on_play_or_draw" class="form-select">
             <option value="play" selected>Play</option>
             <option value="draw">Draw</option>
@@ -18,7 +28,12 @@
 
 <!-- Deck list textarea -->
 <div class="mb-3">
-    <label for="deck_list" class="form-label">Deck List</label>
+    <label for="deck_list" class="form-label">
+        Deck List
+        <a href="#" data-bs-toggle="modal" data-bs-target="#helpDeckList" title="Help">
+            <span class="help-icon">?</span>
+        </a>
+    </label>
     <textarea id="deck_list" name="deck_list" class="form-control" rows="20">
 {% include "deck.txt" %}
     </textarea>
@@ -38,7 +53,7 @@
                 <label for="deck_size" class="form-label">
                     Deck size
                     <a href="#" data-bs-toggle="modal" data-bs-target="#helpDeckSize" title="Help">
-                        <span class="badge bg-info">?</span>
+                        <span class="help-icon">?</span>
                     </a>
                 </label>
                 <input type="number" class="form-control" id="deck_size" name="deck_size" value="40" required>
@@ -47,7 +62,7 @@
                 <label for="hand_size" class="form-label">
                     Initial hand size
                     <a href="#" data-bs-toggle="modal" data-bs-target="#helpHandSize" title="Help">
-                        <span class="badge bg-info">?</span>
+                        <span class="help-icon">?</span>
                     </a>
                 </label>
                 <input type="number" class="form-control" id="hand_size" name="hand_size" value="7" required>
@@ -56,7 +71,7 @@
                 <label for="draws" class="form-label">
                     Number of draw steps
                     <a href="#" data-bs-toggle="modal" data-bs-target="#helpDraws" title="Help">
-                        <span class="badge bg-info">?</span>
+                        <span class="help-icon">?</span>
                     </a>
                 </label>
                 <input type="number" class="form-control" id="draws" name="draws" value="10" required>
@@ -65,7 +80,7 @@
                 <label for="simulations" class="form-label">
                     Number of simulations
                     <a href="#" data-bs-toggle="modal" data-bs-target="#helpSimulations" title="Help">
-                        <span class="badge bg-info">?</span>
+                        <span class="help-icon">?</span>
                     </a>
                 </label>
                 <input type="number" class="form-control" id="simulations" name="simulations" value="200" required>
@@ -74,7 +89,7 @@
                 <label for="seed" class="form-label">
                     Random seed
                     <a href="#" data-bs-toggle="modal" data-bs-target="#helpSeed" title="Help">
-                        <span class="badge bg-info">?</span>
+                        <span class="help-icon">?</span>
                     </a>
                 </label>
                 <input type="number" class="form-control" id="seed" name="seed" value="42" required>


### PR DESCRIPTION
Add help icons to the simulation form and re-arrange the buttons some.

Now appears as:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/67197b89-0e84-401e-8f6c-ec128ff9570b" />

From: https://chatgpt.com/share/67ceda1c-551c-8003-80a4-7fed33a2f4a8